### PR TITLE
Update edown to 0.7 which works with OTP18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {port_env, [ {"CFLAGS", "$CFLAGS -O3"} ]}.
 
 {erl_opts, [debug_info]}.
-{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.5"}}}]}.
+{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.7"}}}]}.
 {src_dirs, ["examples"]}.
 {edoc_opts, [{doclet, edown_doclet},
 	     {src_path, ["src/", "examples/"]},


### PR DESCRIPTION
This is one of the efforts to keep Machi OTP-18 clean.