### PR TITLE
Fix rebar3 crash

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 {so_name, "sext.so"}.
-{src_dirs, ["examples"]}.
+{src_dir, ["example","src"]}.
 {port_source, ["c_src/*.c"]}.
 {port_env, [ {"CFLAGS", "$CFLAGS -O3"} ]}.
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
Fix rebar3 crash on upgrade/tree command, [more info](https://github.com/erlang/rebar3/issues/1622)

